### PR TITLE
Align intelligence field names with server

### DIFF
--- a/notebook-local/src/components/IntentIndicator.tsx
+++ b/notebook-local/src/components/IntentIndicator.tsx
@@ -5,13 +5,13 @@
 import React from "react";
 
 interface IntentIndicatorProps {
-  intentType: string;
-  subCapability: string;
+  intent_type: string;
+  sub_capability: string;
   confidence: number;
   visible: boolean;
 }
 
-export function IntentIndicator({ intentType, subCapability, confidence, visible }: IntentIndicatorProps) {
+export function IntentIndicator({ intent_type, sub_capability, confidence, visible }: IntentIndicatorProps) {
   if (!visible) return null;
   
   // Map intent types to icons and colors
@@ -24,7 +24,7 @@ export function IntentIndicator({ intentType, subCapability, confidence, visible
     'error': { icon: '❌', color: '#6b7280', label: 'Error' }
   };
   
-  const info = intentInfo[intentType as keyof typeof intentInfo] || intentInfo.error;
+  const info = intentInfo[intent_type as keyof typeof intentInfo] || intentInfo.error;
   
   // Confidence indicator
   const confidenceColor = confidence >= 0.8 ? '#10b981' : confidence >= 0.6 ? '#f59e0b' : '#ef4444';
@@ -50,9 +50,9 @@ export function IntentIndicator({ intentType, subCapability, confidence, visible
         {info.label}
       </span>
       
-      {subCapability !== 'general' && (
+      {sub_capability !== 'general' && (
         <span style={{ color: 'var(--text-muted)', fontSize: '10px' }}>
-          {subCapability.replace('_', ' ')}
+          {sub_capability.replace('_', ' ')}
         </span>
       )}
       

--- a/notebook-local/src/components/NotebookLocalView.tsx
+++ b/notebook-local/src/components/NotebookLocalView.tsx
@@ -108,7 +108,7 @@ function ChatInterface({ apiClient }: NotebookLocalViewProps) {
       setLastIntelligenceResponse(intelligenceResponse);
       
       // Show intent and confidence in console for debugging
-      console.log(`🎯 Intent: ${intelligenceResponse.intentType}/${intelligenceResponse.subCapability} (${intelligenceResponse.confidence.toFixed(2)})`);
+      console.log(`🎯 Intent: ${intelligenceResponse.intent_type}/${intelligenceResponse.sub_capability} (${intelligenceResponse.confidence.toFixed(2)})`);
       
     } catch (error) {
       console.error('Intelligent message error:', error);
@@ -486,8 +486,8 @@ function ChatInterface({ apiClient }: NotebookLocalViewProps) {
             {lastIntelligenceResponse && (
               <div style={{ padding: '8px 16px', borderTop: '1px solid var(--background-modifier-border)' }}>
                 <IntentIndicator
-                  intentType={lastIntelligenceResponse.intentType}
-                  subCapability={lastIntelligenceResponse.subCapability}
+                  intent_type={lastIntelligenceResponse.intent_type}
+                  sub_capability={lastIntelligenceResponse.sub_capability}
                   confidence={lastIntelligenceResponse.confidence}
                   visible={true}
                 />

--- a/notebook-local/src/intelligence/IntelligenceController.ts
+++ b/notebook-local/src/intelligence/IntelligenceController.ts
@@ -9,36 +9,36 @@ import { ApiClient } from "../api/ApiClient-clean";
 
 export interface IntelligenceRequest {
   message: string;
-  currentNotePath?: string;
-  conversationHistory?: string[];
-  sessionId?: string;
-  maxTokens?: number;
-  mentionedFiles?: string[];
-  mentionedFolders?: string[];
+  current_note_path?: string;
+  conversation_history?: string[];
+  session_id?: string;
+  max_tokens?: number;
+  mentioned_files?: string[];
+  mentioned_folders?: string[];
 }
 
 export interface IntelligenceResponse {
   content: string;
   sources: string[];
   confidence: number;
-  intentType: string;
-  subCapability: string;
+  intent_type: string;
+  sub_capability: string;
   metadata: Record<string, any>;
-  suggestedActions: string[];
-  sessionId?: string;
+  suggested_actions: string[];
+  session_id?: string;
 }
 
 export interface IntentHint {
-  intentType: string;
+  intent_type: string;
   confidence: number;
-  subCapability: string;
+  sub_capability: string;
   reasoning: string;
 }
 
 export interface CapabilityInfo {
   capabilities: Record<string, any>;
-  totalEngines: number;
-  contextEngine: Record<string, any>;
+  total_engines: number;
+  context_engine: Record<string, any>;
 }
 
 export class IntelligenceController {
@@ -142,9 +142,9 @@ export class IntelligenceController {
       const intelligenceResponse: IntelligenceResponse = await response.json();
       
       // Add response to conversation history for context
-      this.conversationHistory.push(`[Assistant ${intelligenceResponse.intentType}]: ${intelligenceResponse.content.substring(0, 100)}...`);
-      
-      console.log(`✅ Intelligence response: ${intelligenceResponse.intentType} (confidence: ${intelligenceResponse.confidence.toFixed(2)})`);
+      this.conversationHistory.push(`[Assistant ${intelligenceResponse.intent_type}]: ${intelligenceResponse.content.substring(0, 100)}...`);
+
+      console.log(`✅ Intelligence response: ${intelligenceResponse.intent_type} (confidence: ${intelligenceResponse.confidence.toFixed(2)})`);
       
       return intelligenceResponse;
       
@@ -156,11 +156,11 @@ export class IntelligenceController {
         content: `I encountered an error processing your request: ${error.message}`,
         sources: [],
         confidence: 0.0,
-        intentType: 'error',
-        subCapability: 'error',
+        intent_type: 'error',
+        sub_capability: 'error',
         metadata: { error: error.message },
-        suggestedActions: ['Try rephrasing your question', 'Check if server is running'],
-        sessionId: this.sessionId
+        suggested_actions: ['Try rephrasing your question', 'Check if server is running'],
+        session_id: this.sessionId
       };
     }
   }


### PR DESCRIPTION
## Summary
- match TypeScript Intelligence interfaces to snake_case used by server
- update components and controller to access intent_type and sub_capability

## Testing
- `npm test` *(fails: No tests found)*
- `npx tsc -noEmit -skipLibCheck`
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6753d038832aa8fd60fa6eaa6004